### PR TITLE
fix(Change delete to setModerationStatus): youtube.comments.delete won't actually work with other user's comment, using youtube.comments.setModerationStatus instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 token.json
 credentials.json
+node_modules/

--- a/README.md
+++ b/README.md
@@ -54,4 +54,6 @@ Langkah 9: Jalankan Program
 - Tempelkan kembali ke terminal
 - Program akan memindai dan menghapus komentar spam secara otomatis!
 
-Catatan: Saat pertama kali dijalankan, file token.json akan dibuat. Selama file ini ada dan belum kadaluarsa, Anda tidak perlu login ulang di masa depan.
+Catatan:
+- Saat pertama kali dijalankan, file token.json akan dibuat. Selama file ini ada dan belum kadaluarsa, Anda tidak perlu login ulang di masa depan.
+- YouTube Data API v3 memiliki batas penggunaan sebanyak [10.000 API quota units per hari](https://developers.google.com/youtube/v3/determine_quota_cost), sehingga jika anda telah menjalankan program ini beberapa kali dalam sehari, Anda dapat mencapai batas API quota harian sehingga program tidak dapat menghapus komentar hingga besok.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 <h1>Berikut adalah panduan lengkap program pembasmi komen judol</h1>
 
+[Video penjelasan teknis](https://www.youtube.com/watch?v=xnltMa90-f8)
+
 Langkah 1: Instal Node.js
 - Kunjungi situs resmi: https://nodejs.org/
 - Unduh versi LTS (disarankan untuk sebagian besar pengguna)
 - Instal seperti biasa, cukup klik Next hingga selesai
-- Untuk memastikan Node.js dan npm terinstal, buka Command Prompt atau Terminal dan jalankan: node -v
-- npm -v
+- Untuk memastikan Node.js dan npm terinstal, buka Command Prompt atau Terminal dan jalankan: `node -v`
+- `npm -v`
 
 Langkah 2: Instal Visual Studio Code
 - Kunjungi situs resmi: https://code.visualstudio.com/
@@ -13,8 +15,8 @@ Langkah 2: Instal Visual Studio Code
 - Setelah selesai, buka aplikasi Visual Studio Code
 
 Langkah 3: Buat Folder Proyek
-- Di VS Code, klik File → Open Folder → buat folder baru (contoh: YouTubeSpamRemover)
-- Di dalam folder tersebut, buat file baru bernama index.js
+- Di VS Code, klik File → Open Folder → buat folder baru (contoh: `YouTubeSpamRemover`)
+- Di dalam folder tersebut, buat file baru bernama `index.js`
 
 Langkah 4: Aktifkan YouTube Data API dan Buat OAuth Client ID
 - Kunjungi Google Cloud Console: https://console.cloud.google.com/
@@ -32,22 +34,24 @@ Langkah 4: Aktifkan YouTube Data API dan Buat OAuth Client ID
 
 Langkah 5: Buka Terminal di VS Code
 - Di VS Code, klik Terminal → New Terminal
-- Inisialisasi project Node.js dengan menjalankan: npm init -y
+- Inisialisasi project Node.js dengan menjalankan: `npm init -y`
 
 Langkah 6: Instal Library yang Dibutuhkan
-- Jalankan perintah berikut di terminal untuk menginstal package yang diperlukan: npm install googleapis dotenv
+- Jalankan perintah berikut di terminal untuk menginstal package yang diperlukan: `npm install googleapis dotenv`
 
 Langkah 7: Siapkan File
 - Pastikan folder proyek Anda berisi:
-- File credentials.json (dari Google Cloud Console)
-- File .env, lalu isi dengan baris berikut: VIDEO_ID=id_video_youtube_anda
+- File `credentials.json` (dari Google Cloud Console, berawalan `client_secret_` ketika di-download, ubah nama terlebih dahulu)
+- File `.env`, lalu isi dengan baris berikut: `YOUTUBE_CHANNEL_ID=channel_id_anda`
+> [!IMPORTANT]
+> Channel ID dapat ditemukan pada laman https://www.youtube.com/account_advanced
 
 Langkah 8: Masukkan Kode Program
 - Salin dan tempel seluruh kode JavaScript ke dalam file index.js.
 
 Langkah 9: Jalankan Program
 - Di terminal, jalankan:
-  - node index.js
+  - `node index.js`
 - Terminal akan menampilkan URL — salin dan buka di browser
 - Login dengan akun YouTube Anda dan berikan izin akses
 - Setelah itu, browser akan mengarahkan Anda ke localhost dengan sebuah “code” — salin kodenya

--- a/index.js
+++ b/index.js
@@ -124,28 +124,28 @@ async function youtubeContentList(auth) {
     const youtube = google.youtube({ version: "v3", auth });
 
     try {
-    const response = await youtube.channels.list({
-        part: "contentDetails",
-        id: youtubeChannelID, // ← use forUsername if you're passing a name
-    });
-
-    const channel = response.data.items[0];
-    const uploadsPlaylistId = channel.contentDetails.relatedPlaylists.uploads;
-
-    const allVideos = [];
-    let nextPageToken = "";
-
-    do {
-        const playlistResponse = await youtube.playlistItems.list({
-            part: "snippet",
-            playlistId: uploadsPlaylistId,
-            maxResults: 50,
-            pageToken: nextPageToken,
+        const response = await youtube.channels.list({
+            part: "contentDetails",
+            id: youtubeChannelID, // ← use forUsername if you're passing a name
         });
 
-        allVideos.push(...playlistResponse.data.items);
-        nextPageToken = playlistResponse.data.nextPageToken;
-    } while (nextPageToken);
+        const channel = response.data.items[0];
+        const uploadsPlaylistId = channel.contentDetails.relatedPlaylists.uploads;
+
+        const allVideos = [];
+        let nextPageToken = "";
+
+        do {
+            const playlistResponse = await youtube.playlistItems.list({
+                part: "snippet",
+                playlistId: uploadsPlaylistId,
+                maxResults: 50,
+                pageToken: nextPageToken,
+            });
+
+            allVideos.push(...playlistResponse.data.items);
+            nextPageToken = playlistResponse.data.nextPageToken;
+        } while (nextPageToken);
         return allVideos;
     } catch (error) {
         console.error("Error fetching videos:", error);

--- a/index.js
+++ b/index.js
@@ -101,14 +101,20 @@ function getJudolComment(text) {
 async function deleteComments(auth, commentIds) {
     const youtube = google.youtube({ version: "v3", auth });
 
-    for (const commentId of commentIds) {
+    const totalCommentsToBeDeleted = commentIds.length;
+    let totalDeletedComments = 0;
+    do{
+        const commentIdsChunk = commentIds.splice(0,50);
+        if (commentIdsChunk.length === 0) break;
         try {
-            await youtube.comments.delete({ id: commentId });
-            console.log(`Deleted comment: ${commentId}`);
+            await youtube.comments.setModerationStatus(commentIdsChunk, `rejected`);
+            totalDeletedComments += commentIdsChunk.length;
+            console.log(`Progress: ${totalDeletedComments}/${totalCommentsToBeDeleted} (${commentIds.length} remaining)
+Deleted the following comment IDs:`, commentIdsChunk);
         } catch (error) {
-            console.error(`Failed to delete comment ${commentId}:`, error.message);
+            console.error(`Failed to delete these comment IDs: ${commentIdsChunk}:`, error.message);
         }
-    }
+    } while (commentIds.length > 0);
 }
 
 async function youtubeContentList(auth) {

--- a/index.js
+++ b/index.js
@@ -107,7 +107,10 @@ async function deleteComments(auth, commentIds) {
         const commentIdsChunk = commentIds.splice(0,50);
         if (commentIdsChunk.length === 0) break;
         try {
-            await youtube.comments.setModerationStatus(commentIdsChunk, `rejected`);
+            await youtube.comments.setModerationStatus({
+                id: commentIdsChunk,
+                moderationStatus: "rejected"
+            });
             totalDeletedComments += commentIdsChunk.length;
             console.log(`Progress: ${totalDeletedComments}/${totalCommentsToBeDeleted} (${commentIds.length} remaining)
 Deleted the following comment IDs:`, commentIdsChunk);


### PR DESCRIPTION
Fungsi `youtube.comments.delete` hanya dapat digunakan pada komentar yang dibuat oleh channel sendiri atau orang yang meng-authorize OAuth API, berdasarkan https://stackoverflow.com/a/41130250

Dengan menggunakan `youtube.comments.setModerationStatus`, kita dapat menghapus komentar orang lain. Menggunakan `setModerationStatus` juga menghemat API quota *up-to* 50 kali lebih sedikit.

Selain itu, README.md di-update untuk memperingatkan pengguna tentang batasan API quota per hari pada YouTube Data API v3

Referensi:
- https://github.com/ThioJoe/YT-Spammer-Purge/blob/91816f312807454b74a93abd3d6849cf4af3fac5/Scripts/operations.py#L1092 (menggunakan fungsi `setModerationStatus` untuk menghapus)
- https://github.com/ThioJoe/YT-Spammer-Purge/blob/91816f312807454b74a93abd3d6849cf4af3fac5/YTSpammerPurge.py#L1491 (variable `deletionStatus` disetel ke `rejected`, pada `operations.py` di atas moderationStatus sama dengan deletionStatus, sehingga untuk menghapus komentar gunakan `moderationStatus: "rejected"`)
- https://github.com/explor4268/yt-spam-comment-buster/blob/2470b0b10d118ec2c63bfdef71b8aaf8f6871e62/src/apps-script/main.gs#L105 (Implementasi versi saya, penggunaan API sedikit berbeda karena menggunakan Google Apps Script)